### PR TITLE
test: 비밀번호가 걸린 letter를 찾을때 비밀번호 없이는 가져올수 없는지 확인

### DIFF
--- a/src/api/letter/__test__/letter.service.e2e.test.ts
+++ b/src/api/letter/__test__/letter.service.e2e.test.ts
@@ -1,0 +1,41 @@
+import { Test } from '@nestjs/testing';
+import { AppModule } from '../../../app.module';
+import { LetterService } from '../letter.service';
+import {
+  LetterRepository,
+  LetterRepositoryModule,
+} from '../../../common/database';
+import { BadRequestException } from '@nestjs/common';
+import { CryptoManagerModule } from '../../../common/service';
+
+describe('LetterService', () => {
+  let letterRepository: LetterRepository;
+  let letterService: LetterService;
+
+  beforeEach(async () => {
+    const app = await Test.createTestingModule({
+      imports: [AppModule, CryptoManagerModule, LetterRepositoryModule],
+      providers: [LetterService],
+    }).compile();
+
+    letterRepository = app.get<LetterRepository>(LetterRepository);
+    letterService = app.get<LetterService>(LetterService);
+  });
+
+  it('비밀번호가 걸린 편지는 비밀번호 없이 가져올수 없다.', async () => {
+    // given
+    const linkId = 1;
+    await letterRepository.create({
+      title: 'title',
+      content: 'content',
+      writer: 'writer',
+      linkId: linkId,
+      password: 'password',
+    });
+
+    // when
+    await expect(async () => {
+      await letterService.findLetter(linkId);
+    }).rejects.toThrowError(new BadRequestException('Password is wrong'));
+  });
+});


### PR DESCRIPTION
### 구현 내용
- 비밀번호가 걸린 letter를 찾을때 비밀번호 없이는 가져올수 없는지 확인하는 테스트 작성

### 특이사항
- 비밀번호 파라미터가 없이 들어오는경우 password에 대한 where문 자체가 안생겨서 비밀번호가 걸려있어도 볼수 있는 버그 수정에 대한 테스트